### PR TITLE
Sets image subview autoresizingMasks to ensure subviews resize in lockst...

### DIFF
--- a/KASlideShow/KASlideShow.m
+++ b/KASlideShow/KASlideShow.m
@@ -68,6 +68,7 @@ typedef NS_ENUM(NSInteger, KASlideShowSlideMode) {
     
     _topImageView = [[UIImageView alloc] initWithFrame:self.bounds];
     _bottomImageView = [[UIImageView alloc] initWithFrame:self.bounds];
+    _topImageView.autoresizingMask = _bottomImageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     _topImageView.clipsToBounds = YES;
     _bottomImageView.clipsToBounds = YES;
     [self setImagesContentMode:UIViewContentModeScaleAspectFit];


### PR DESCRIPTION
...ep with superview

Fixes issue of image views not resizing when KASlideShow resizes due to rotation.
