### PR TITLE
Fixed bugs:

### DIFF
--- a/KASlideShow/KASlideShow.h
+++ b/KASlideShow/KASlideShow.h
@@ -64,6 +64,7 @@ typedef NS_ENUM(NSUInteger, KASlideShowState) {
 
 - (void) addImagesFromResources:(NSArray *) names;
 - (void) emptyAndAddImagesFromResources:(NSArray *)names;
+- (void) setImagesDataSource:(NSMutableArray *)array;
 - (void) addGesture:(KASlideShowGestureType)gestureType;
 - (void) addImage:(UIImage *) image;
 - (void) start;

--- a/KASlideShow/KASlideShow.m
+++ b/KASlideShow/KASlideShow.m
@@ -54,6 +54,13 @@ typedef NS_ENUM(NSInteger, KASlideShowSlideMode) {
     return self;
 }
 
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    
+    _topImageView.frame = frame;
+    _bottomImageView.frame = frame;
+}
+
 - (void) setDefaultValues
 {
     self.clipsToBounds = YES;
@@ -112,6 +119,12 @@ typedef NS_ENUM(NSInteger, KASlideShowSlideMode) {
     for(NSString * name in names){
         [self addImage:[UIImage imageNamed:name]];
     }
+}
+
+- (void) setImagesDataSource:(NSMutableArray *)array {
+    self.images = array;
+    
+    _topImageView.image = [array firstObject];
 }
 
 - (void) addImage:(UIImage*) image
@@ -180,7 +193,7 @@ typedef NS_ENUM(NSInteger, KASlideShowSlideMode) {
     if(! _isAnimating && ([self.images count] >1 || self.dataSource)){
         
         if ([self.delegate respondsToSelector:@selector(kaSlideShowWillShowPrevious:)]) [self.delegate kaSlideShowWillShowPrevious:self];
-
+        
         // Previous image
         if (self.dataSource) {
             _topImageView.image = [self.dataSource slideShow:self imageForPosition:KASlideShowPositionTop];


### PR DESCRIPTION
```
1) after setting - [KASlideShow setImages:] the _topImageView wasn’t updating resulting in a transparent view;
2) after setting - [KSSlideShow setFrame:] the _topImageView & _bottomImageView wasn’t updating their frame.
```
